### PR TITLE
merge from master

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,3 +22,5 @@ dags/sparsity_diffusion_devx/configs/project_bite* @RissyRan @parambole @jiangjy
 dags/inference @vipannalla @mailvijayasingh @sixiang-google @joezijunzhou @singh-mitali
 
 dags/map_reproducibility @crankshaw-google @polydier1 @gunjanj007 @stingram @utkarshsharma1 @cneel8986 @Doris26 @wang2yn84 @zshu188
+
+dags/orbax @abhinavclemson @xuefgu

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,15 +11,15 @@ dags/legacy_test/tests/pytorch @vanbasten23 @zpcore @ManfeiBai
 
 dags/mantaray @ManfeiBai @tengyifei @zpcore
 
-dags/multipod @tonyjohnchen @raymondzouu @gobbleturk @shralex @RissyRan @jiangjy1982
+dags/multipod @tonyjohnchen @raymondzouu @gobbleturk @shralex @RissyRan @jiangjy1982 @notabee
 
 dags/mlcompass @ortibazar @sganeshb @brajiang @wlzhg
 
-dags/sparsity_diffusion_devx @RissyRan @parambole @jiangjy1982 @aireenmei @michelle-yooh
+dags/sparsity_diffusion_devx @RissyRan @parambole @jiangjy1982 @aireenmei @michelle-yooh @notabee
 dags/sparsity_diffusion_devx/project_bite* @RissyRan @parambole @jiangjy1982 @aireenmei @michelle-yooh @jiya-zhang
 dags/sparsity_diffusion_devx/configs/project_bite* @RissyRan @parambole @jiangjy1982 @aireenmei @michelle-yooh @jiya-zhang
 
-dags/inference @vipannalla @mailvijayasingh @sixiang-google @joezijunzhou @singh-mitali
+dags/inference @vipannalla @mailvijayasingh @sixiang-google @joezijunzhou
 
 dags/map_reproducibility @crankshaw-google @polydier1 @gunjanj007 @stingram @utkarshsharma1 @cneel8986 @Doris26 @wang2yn84 @zshu188
 

--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -2,10 +2,10 @@ sqlalchemy-spanner==1.11.0
 apache-airflow==2.10.2
 apache-airflow-providers-sendgrid
 fabric
-google-cloud-bigquery
-google-cloud-compute
-google-cloud-storage
-google-cloud-container
+google-cloud-bigquery>=3.29.0
+google-cloud-compute>=1.26.0
+google-cloud-storage>=2.18.2
+google-cloud-container>=2.54.0
 google-cloud-tpu>=1.16.0
 jsonlines
 tensorflow-cpu

--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,3 +1,4 @@
+sqlalchemy-spanner==1.11.0
 apache-airflow==2.10.2
 apache-airflow-providers-sendgrid
 fabric

--- a/dags/common/model_configs.py
+++ b/dags/common/model_configs.py
@@ -25,7 +25,16 @@ class MaxTextV5eModelConfigs(enum.Enum):
   DEFAULT_128B = "default_128b_v5e_256"
   GPT3_175B = "gpt_3_175b_v5e_256"
   LLAMA2_7B = "llama2_7b_v5e_256"
+  LLAMA2_13B = "llama2_13b_v5e_256"
   LLAMA2_70B = "llama2_70b_v5e_256"
+
+
+class MaxTextV5pModelConfigs(enum.Enum):
+  # Refers to model configs in https://github.com/AI-Hypercomputer/maxtext/blob/main/benchmarks/maxtext_v5p_model_configs.py
+  GPT3_175B = "gpt_3_175b_v5p_128"
+  GPT3_175B_SC = "gpt_3_175b_v5p_128_sc"
+  LLAMA2_7B = "llama2_7b_v5p_128"
+  LLAMA2_70B = "llama2_70b_v5p_128"
 
 
 class MaxTextTrilliumModelConfigs(enum.Enum):

--- a/dags/common/test_owner.py
+++ b/dags/common/test_owner.py
@@ -50,6 +50,7 @@ ZHIYU_L = "Zhiyu L."
 MOHIT_K = "Mohit K."
 ANISHA_M = "Anisha M."
 YUWEI_Y = "Yuwei Y."
+RISHABH_B = "Rishabh B."
 
 # Multi-tier Checkpointing
 ABHINAV_S = "ABHINAV S."

--- a/dags/common/vm_resource.py
+++ b/dags/common/vm_resource.py
@@ -249,6 +249,13 @@ class XpkClusters:
       project=Project.CLOUD_TPU_MULTIPOD_DEV.value,
       zone=Zone.EUROPE_WEST4_B.value,
   )
+  TPU_V5P_128_CLUSTER = XpkClusterConfig(
+      name="v5p-128-bodaborg-europe-west4-b",
+      device_version=TpuVersion.V5P,
+      core_count=128,
+      project=Project.CLOUD_TPU_MULTIPOD_DEV.value,
+      zone=Zone.EUROPE_WEST4_B.value,
+  )
   TPU_V5E_256_CLUSTER = XpkClusterConfig(
       name="v5e-256-bodaborg-europe-west4",
       device_version=TpuVersion.V5E,

--- a/dags/map_reproducibility/a4/llama3_1_70b/maxtext.py
+++ b/dags/map_reproducibility/a4/llama3_1_70b/maxtext.py
@@ -19,26 +19,24 @@ from airflow import models
 from dags import composer_env
 
 from dags.map_reproducibility.utils.common_utils import get_scheduled_time
-from dags.map_reproducibility.utils.common_utils import run_maxtext_workload
+from dags.map_reproducibility.utils.common_utils import run_workload
 
 
 MODEL_ID = "llama3-1-70b"
+METRICS_MODEL_ID = "llama3.1-70b"
 PRECISION = "fp8"
 HYPERCOMPUTER = "a4"
 FRAMEWORK = "maxtext"
+WORKLOAD_LAUNCHER = "maxtext-launcher.sh"
+KUEUE_NAME = None
+OPTIMIZER = "adam"
+NUM_STEPS = 30
 
 SCHEDULED_TIME = (
     get_scheduled_time(HYPERCOMPUTER, MODEL_ID, FRAMEWORK)
     if composer_env.is_prod_env()
     else None
 )
-
-KUEUE_NAME = "a4-high"
-OPTIMIZER = "adam"
-SEQUENCE_LENGTH = 2048
-NUM_STEPS = 30
-BATCH_SIZE_PER_DEVICE = 8
-
 
 with models.DAG(
     dag_id=f"{HYPERCOMPUTER}_recipes_{MODEL_ID}_{FRAMEWORK}",
@@ -53,15 +51,15 @@ with models.DAG(
     start_date=datetime.datetime(2024, 11, 15),
     catchup=False,
 ) as dag:
-  run_maxtext_workload(
+  run_workload(
       hypercomputer=HYPERCOMPUTER,
       model_id=MODEL_ID,
       framework=FRAMEWORK,
       precision=PRECISION,
       num_steps=NUM_STEPS,
-      batch_size_per_device=BATCH_SIZE_PER_DEVICE,
       kueue_name=KUEUE_NAME,
+      metrics_model_id=METRICS_MODEL_ID,
       optimizer=OPTIMIZER,
-      sequence_length=SEQUENCE_LENGTH,
-      helm_model_id=MODEL_ID,
+      workload_launcher=WORKLOAD_LAUNCHER,
+      config_model_name=f"llama3-1-70b-256gpus-a4-{PRECISION}.yaml",
   )

--- a/dags/map_reproducibility/a4/llama3_1_70b/nemo.py
+++ b/dags/map_reproducibility/a4/llama3_1_70b/nemo.py
@@ -19,15 +19,17 @@ import datetime
 from airflow import models
 from dags import composer_env
 from dags.map_reproducibility.utils.common_utils import get_scheduled_time
-from dags.map_reproducibility.utils.common_utils import run_nemo_workload
+from dags.map_reproducibility.utils.common_utils import run_workload
 
 
 MODEL_ID = "llama3-1-70b"
 METRICS_MODEL_ID = "llama3.1-70b"
 PRECISION = "fp8"
-KUEUE_NAME = "a4-high"
+KUEUE_NAME = None
 HYPERCOMPUTER = "a4"
 FRAMEWORK = "nemo"
+WORKLOAD_LAUNCHER = "nemo-10-launcher.sh"
+
 SCHEDULED_TIME = (
     get_scheduled_time(HYPERCOMPUTER, MODEL_ID, FRAMEWORK)
     if composer_env.is_prod_env()
@@ -47,11 +49,12 @@ with models.DAG(
     start_date=datetime.datetime(2025, 3, 1),
     catchup=False,
 ) as dag:
-  run_nemo_workload(
+  run_workload(
       hypercomputer=HYPERCOMPUTER,
       model_id=MODEL_ID,
       framework=FRAMEWORK,
       precision=PRECISION,
+      kueue_name=KUEUE_NAME,
       metrics_model_id=METRICS_MODEL_ID,
-      config_model_name="llama3-1-70b-256gpus-a4-fp8.yaml",
+      workload_launcher=WORKLOAD_LAUNCHER,
   )

--- a/dags/map_reproducibility/a4/llama_3_1_405b/maxtext.py
+++ b/dags/map_reproducibility/a4/llama_3_1_405b/maxtext.py
@@ -18,29 +18,24 @@ import datetime
 from airflow import models
 from dags import composer_env
 
-from dags.map_reproducibility.utils.common_utils import get_cluster
 from dags.map_reproducibility.utils.common_utils import get_scheduled_time
-from dags.map_reproducibility.utils.common_utils import get_docker_image
-from dags.map_reproducibility.utils.common_utils import run_maxtext_workload
-
+from dags.map_reproducibility.utils.common_utils import run_workload
 
 MODEL_ID = "llama3-1-405b"
+METRICS_MODEL_ID = "llama3.1-405b"
 PRECISION = "fp8"
 HYPERCOMPUTER = "a4"
 FRAMEWORK = "maxtext"
+WORKLOAD_LAUNCHER = "maxtext-launcher.sh"
+KUEUE_NAME = None
+OPTIMIZER = "adam"
+NUM_STEPS = 30
 
 SCHEDULED_TIME = (
     get_scheduled_time(HYPERCOMPUTER, MODEL_ID, FRAMEWORK)
     if composer_env.is_prod_env()
     else None
 )
-
-KUEUE_NAME = "a4-high"
-OPTIMIZER = "adam"
-SEQUENCE_LENGTH = 2048
-NUM_STEPS = 30
-BATCH_SIZE_PER_DEVICE = 2
-
 
 with models.DAG(
     dag_id=f"{HYPERCOMPUTER}_recipes_{MODEL_ID}_{FRAMEWORK}",
@@ -55,15 +50,15 @@ with models.DAG(
     start_date=datetime.datetime(2024, 11, 15),
     catchup=False,
 ) as dag:
-  run_maxtext_workload(
+  run_workload(
       hypercomputer=HYPERCOMPUTER,
       model_id=MODEL_ID,
       framework=FRAMEWORK,
       precision=PRECISION,
       num_steps=NUM_STEPS,
-      batch_size_per_device=BATCH_SIZE_PER_DEVICE,
       kueue_name=KUEUE_NAME,
+      metrics_model_id=METRICS_MODEL_ID,
       optimizer=OPTIMIZER,
-      sequence_length=SEQUENCE_LENGTH,
-      helm_model_id=MODEL_ID,
+      workload_launcher=WORKLOAD_LAUNCHER,
+      config_model_name=f"llama3-1-405b-256gpus-a4-{PRECISION}.yaml",
   )

--- a/dags/map_reproducibility/a4/llama_3_1_405b/nemo.py
+++ b/dags/map_reproducibility/a4/llama_3_1_405b/nemo.py
@@ -19,15 +19,17 @@ import datetime
 from airflow import models
 from dags import composer_env
 from dags.map_reproducibility.utils.common_utils import get_scheduled_time
-from dags.map_reproducibility.utils.common_utils import run_nemo_workload
+from dags.map_reproducibility.utils.common_utils import run_workload
 
 
 MODEL_ID = "llama3-1-405b"
 METRICS_MODEL_ID = "llama3.1-405b"
 PRECISION = "bf16"
-KUEUE_NAME = "a4-high"
+KUEUE_NAME = None
 HYPERCOMPUTER = "a4"
 FRAMEWORK = "nemo"
+WORKLOAD_LAUNCHER = "nemo-10-launcher.sh"
+
 SCHEDULED_TIME = (
     get_scheduled_time(HYPERCOMPUTER, MODEL_ID, FRAMEWORK)
     if composer_env.is_prod_env()
@@ -48,11 +50,12 @@ with models.DAG(
     start_date=datetime.datetime(2025, 3, 1),
     catchup=False,
 ) as dag:
-  run_nemo_workload(
+  run_workload(
       hypercomputer=HYPERCOMPUTER,
       model_id=MODEL_ID,
       framework=FRAMEWORK,
       precision=PRECISION,
+      kueue_name=KUEUE_NAME,
       metrics_model_id=METRICS_MODEL_ID,
-      config_model_name="llama3-1-405b-224gpus-a4-bf16.yaml",
+      workload_launcher=WORKLOAD_LAUNCHER,
   )

--- a/dags/map_reproducibility/a4/mixtral_8_7b/nemo.py
+++ b/dags/map_reproducibility/a4/mixtral_8_7b/nemo.py
@@ -19,21 +19,23 @@ import datetime
 from airflow import models
 from dags import composer_env
 from dags.map_reproducibility.utils.common_utils import get_scheduled_time
-from dags.map_reproducibility.utils.common_utils import run_nemo_workload
+from dags.map_reproducibility.utils.common_utils import run_workload
 
 
 MODEL_ID = "mixtral-8x7b"
 METRICS_MODEL_ID = "mixtral-7b"
 PRECISION = "bf16"
-KUEUE_NAME = "a4-high"
+KUEUE_NAME = None
 HYPERCOMPUTER = "a4"
 FRAMEWORK = "nemo"
+WORKLOAD_LAUNCHER = "nemo-10-launcher.sh"
+NUM_GPUS = 16
+
 SCHEDULED_TIME = (
     get_scheduled_time(HYPERCOMPUTER, MODEL_ID, FRAMEWORK)
     if composer_env.is_prod_env()
     else None
 )
-
 
 with models.DAG(
     dag_id=f"{HYPERCOMPUTER}_recipes_{MODEL_ID}_{FRAMEWORK}",
@@ -48,11 +50,13 @@ with models.DAG(
     start_date=datetime.datetime(2025, 3, 1),
     catchup=False,
 ) as dag:
-  run_nemo_workload(
+  run_workload(
       hypercomputer=HYPERCOMPUTER,
       model_id=MODEL_ID,
       framework=FRAMEWORK,
       precision=PRECISION,
+      kueue_name=KUEUE_NAME,
       metrics_model_id=METRICS_MODEL_ID,
       config_model_name=f"{MODEL_ID}-16-32-gpus-{HYPERCOMPUTER}-{PRECISION}.yaml",
+      workload_launcher=WORKLOAD_LAUNCHER,
   )

--- a/dags/map_reproducibility/a4/two_node_nemo.py
+++ b/dags/map_reproducibility/a4/two_node_nemo.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,9 +18,7 @@ import datetime
 
 from airflow import models
 from dags import composer_env
-from dags.map_reproducibility.utils.common_utils import get_cluster
-from dags.map_reproducibility.utils.common_utils import get_docker_image
-from dags.map_reproducibility.utils.common_utils import run_nemo_workload
+from dags.map_reproducibility.utils.common_utils import run_workload
 
 
 MODEL_ID = "mixtral-8x7b"
@@ -28,18 +26,13 @@ METRICS_MODEL_ID = "mixtral-7b"
 PRECISION = "bf16"
 HYPERCOMPUTER = "a4"
 FRAMEWORK = "nemo"
-KUEUE_NAME = "a4-high"
+WORKLOAD_LAUNCHER = "nemo-10-launcher.sh"
 
 SCHEDULED_TIME = "0 6 * * *" if composer_env.is_prod_env() else None
 
-VALUE_YAML_PATH = (
-    f"training/{HYPERCOMPUTER}/{MODEL_ID}/nemo-pretraining-gke/values.yaml"
-)
-CLUSTER, CLUSTER_REGION = get_cluster(HYPERCOMPUTER)
-SOFTWARE_ID = "pytorch_nemo"
-IMAGE_VERSION = "nemo24.07"
-DOCKER_IMAGE = get_docker_image(HYPERCOMPUTER, FRAMEWORK)
-
+KUEUE_NAME = None
+NUM_GPUS = 16
+NUM_STEPS = 1
 
 with models.DAG(
     dag_id=f"{HYPERCOMPUTER}_recipes_two_node_{FRAMEWORK}",
@@ -54,13 +47,15 @@ with models.DAG(
     start_date=datetime.datetime(2024, 11, 15),
     catchup=False,
 ) as dag:
-  run_nemo_workload(
+  run_workload(
       hypercomputer=HYPERCOMPUTER,
       model_id=MODEL_ID,
       framework=FRAMEWORK,
       precision=PRECISION,
+      kueue_name=KUEUE_NAME,
       metrics_model_id=METRICS_MODEL_ID,
-      two_node=True,
+      num_gpus=NUM_GPUS,
+      num_steps=NUM_STEPS,
       config_model_name=f"{MODEL_ID}-16-32-gpus-{HYPERCOMPUTER}-{PRECISION}.yaml",
-      kueue_name="a4-high",
+      workload_launcher=WORKLOAD_LAUNCHER,
   )

--- a/dags/map_reproducibility/utils/common_utils.py
+++ b/dags/map_reproducibility/utils/common_utils.py
@@ -1803,6 +1803,7 @@ def run_workload(
     kueue_name: str = None,
     config_model_name: str = None,
     optimizer: Optional[str] = None,
+    workload_type: str = "jobset",
 ):
   with tempfile.TemporaryDirectory() as tmpdir:
     hook = SubprocessHook()
@@ -1887,6 +1888,12 @@ def run_workload(
     else:
       metrics_cmd = ()
 
+    wait_cmd = (
+        wait_for_jobsets_cmds
+        if workload_type == "jobset"
+        else wait_for_jobs_cmds
+    )
+
     result = hook.run_command(
         [
             "bash",
@@ -1909,7 +1916,7 @@ def run_workload(
                     additional_cmds=additional_cmds,
                     num_steps=num_steps,
                 )
-                + wait_for_jobs_cmds()
+                + wait_cmd()
                 + copy_bucket_cmds_workload(
                     recipe_repo_root=recipe_repo_root,
                     tmpdir=tmpdir,

--- a/dags/map_reproducibility/utils/common_utils.py
+++ b/dags/map_reproducibility/utils/common_utils.py
@@ -1056,9 +1056,9 @@ def get_cluster(hardware: str = "a3ultra"):
   if hardware == "a3mega":
     return "a3plus-benchmark", "australia-southeast1"
   if hardware == "a3ultra":
-    return "gke-a3ultra-bm-map-3", "europe-west1"
+    return "imo-a3ultra", "europe-west1"
   if hardware == "a4":
-    return "gke-a4-shared", "us-central1"
+    return "gke-a4-sbrg1", "us-east4"
 
 
 def get_scheduled_time(hardware: str, model: str, framework: str):

--- a/dags/map_reproducibility/utils/common_utils.py
+++ b/dags/map_reproducibility/utils/common_utils.py
@@ -789,8 +789,13 @@ def get_nemo_metrics_cmds(
 
 def cleanup_all_runs_cmds(cluster, cluster_region, prefix="cml-"):
   cleanup_cmds = (
-      f"echo 'Getting credentials for cluster {cluster}...' && gcloud container clusters get-credentials {cluster} --region {cluster_region} --project {PROJECT} ",
-      f"echo 'Uninstalling jobs with prefix {prefix}...' && JOBS=$(kubectl get job -n default | grep \"^{prefix}\" | awk '{{print $1}}') && if [ -n \"$JOBS\" ]; then echo \"$JOBS\" | xargs -L1 helm uninstall -n default; else echo 'No matching jobs found'; fi",
+      f"echo 'Getting credentials for cluster {cluster}...' && gcloud container clusters get-credentials {cluster} --region {cluster_region} --project {PROJECT}",
+      f"echo 'Uninstalling jobs with prefix {prefix}...' && "
+      f"JOBS=$(kubectl get job -n default | grep '^{prefix}' | awk '{{print $1}}' | sed 's/-workload-0$//' | sort -u) && "
+      f'if [ -n "$JOBS" ]; then '
+      f'echo "$JOBS" | xargs -L1 helm uninstall -n default || true && '
+      f'echo "$JOBS" | xargs -L1 kubectl delete job -n default || true; '
+      f"else echo 'No matching jobs found'; fi",
   )
   return cleanup_cmds
 

--- a/dags/multipod/legacy.py
+++ b/dags/multipod/legacy.py
@@ -25,7 +25,7 @@ from dags.multipod.configs.common import SetupMode, Platform
 # Run once a day at 9 am UTC (1 am PST)
 SCHEDULED_TIME = "0 9 * * *" if composer_env.is_prod_env() else None
 DOCKER_IMAGE = {
-    SetupMode.STABLE: DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK,
+    SetupMode.STABLE: DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE,
     SetupMode.NIGHTLY: DockerImage.MAXTEXT_TPU_JAX_NIGHTLY,
 }
 

--- a/dags/multipod/maxtext_checkpointing.py
+++ b/dags/multipod/maxtext_checkpointing.py
@@ -45,7 +45,7 @@ with models.DAG(
   current_time = datetime.datetime.now()
   current_datetime = current_time.strftime("%Y-%m-%d-%H-%M-%S")
   docker_images = [
-      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
+      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE),
       (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
   ]
   test_configs = {

--- a/dags/multipod/maxtext_convergence.py
+++ b/dags/multipod/maxtext_convergence.py
@@ -76,7 +76,7 @@ with models.DAG(
         time_out_in_min=300,
         test_name=test_name,
         run_model_cmds=run_command,
-        docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK.value,
+        docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE.value,
         test_owner=test_owner.MATT_D,
         base_output_directory=base_output_directory,
         metric_aggregation_strategy=metric_config.AggregationStrategy.LAST,

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -64,7 +64,8 @@ with models.DAG(
             f"bash end_to_end/{test_script}.sh",
         ),
         docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK.value,
-        test_owner=test_owner.JON_B,
+        cluster=XpkClusters.TPU_V5P_8_CLUSTER,
+        test_owner=test_owner.MOHIT_K,
     ).run_with_quarantine(quarantine_task_group)
     nightly_tpu = gke_config.get_gke_config(
         time_out_in_min=60,
@@ -74,7 +75,8 @@ with models.DAG(
             f"bash end_to_end/{test_script}.sh",
         ),
         docker_image=DockerImage.MAXTEXT_TPU_JAX_NIGHTLY.value,
-        test_owner=test_owner.JON_B,
+        cluster=XpkClusters.TPU_V5P_8_CLUSTER,
+        test_owner=test_owner.MOHIT_K,
     ).run_with_quarantine(quarantine_task_group)
     stable_tpu >> nightly_tpu
 
@@ -87,7 +89,7 @@ with models.DAG(
           },
           {
               "script_name": "tpu/gemma/7b/2_test_gemma",
-              "cluster": XpkClusters.TPU_V4_16_CLUSTER,
+              "cluster": XpkClusters.TPU_V5P_8_CLUSTER,
               "time_out_in_min": 60,
           },
       ],
@@ -99,7 +101,7 @@ with models.DAG(
           },
           {
               "script_name": "tpu/llama2/70b/2_test_llama2_70b",
-              "cluster": XpkClusters.TPU_V4_128_CLUSTER,
+              "cluster": XpkClusters.TPU_V5P_128_CLUSTER,
               "time_out_in_min": 60,
           },
       ],

--- a/dags/multipod/maxtext_end_to_end.py
+++ b/dags/multipod/maxtext_end_to_end.py
@@ -63,7 +63,7 @@ with models.DAG(
             f"export HF_TOKEN={HF_TOKEN}",
             f"bash end_to_end/{test_script}.sh",
         ),
-        docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK.value,
+        docker_image=DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE.value,
         cluster=XpkClusters.TPU_V5P_8_CLUSTER,
         test_owner=test_owner.MOHIT_K,
     ).run_with_quarantine(quarantine_task_group)
@@ -146,7 +146,7 @@ with models.DAG(
       return conversion_cpu, training_tpu
 
   docker_image = {
-      "stable": DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK.value,
+      "stable": DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE.value,
       "nightly": DockerImage.MAXTEXT_TPU_JAX_NIGHTLY.value,
   }
   tests = []

--- a/dags/multipod/maxtext_sft_trainer.py
+++ b/dags/multipod/maxtext_sft_trainer.py
@@ -36,7 +36,7 @@ with models.DAG(
 ) as dag:
   base_output_directory = f'{gcs_bucket.BASE_OUTPUT_DIR}/maxtext_sft_trainer'
   docker_images = [
-      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
+      (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK_CANDIDATE),
       (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
   ]
 

--- a/dags/multipod/maxtext_v5p_configs_perf.py
+++ b/dags/multipod/maxtext_v5p_configs_perf.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+A DAG to run perf tests for MaxText model configs on V5p.
+"""
+import datetime
+from airflow import models
+from airflow.utils.task_group import TaskGroup
+from dags import composer_env
+from dags.common import test_owner
+from dags.common.vm_resource import Project, XpkClusters, DockerImage
+from dags.common.model_configs import MaxTextV5pModelConfigs
+from dags.multipod.configs import maxtext_sweep_gke_config
+from dags.multipod.configs.common import SetupMode
+from xlml.apis import metric_config
+
+# Run once a day at 4 am UTC (8 pm PST / 9 pm PDT)
+SCHEDULED_TIME = "0 4 * * *" if composer_env.is_prod_env() else None
+DOCKER_IMAGES = [
+    (SetupMode.STABLE, DockerImage.MAXTEXT_TPU_JAX_STABLE_STACK),
+    (SetupMode.NIGHTLY, DockerImage.MAXTEXT_TPU_JAX_NIGHTLY),
+]
+QUANTIZATION_SWEEP = {"M_QUANTIZATION": ["", "int8"]}
+BASE_OUTPUT_DIRECTORY = "gs://runner-maxtext-logs"
+
+with models.DAG(
+    dag_id="maxtext_v5p_configs_perf",
+    schedule=SCHEDULED_TIME,
+    tags=[
+        "multipod_team",
+        "maxtext",
+        "stable",
+        "nightly",
+        "mlscale_perfx",
+    ],
+    start_date=datetime.datetime(2024, 2, 19),
+    catchup=False,
+) as dag:
+  quarantine_task_group = TaskGroup(
+      group_id="Quarantine", dag=dag, prefix_group_id=False
+  )
+  for mode, image in DOCKER_IMAGES:
+    for model in MaxTextV5pModelConfigs:
+      base_run_model_cmds = [
+          "bash preflight.sh",
+          f"python3 -m benchmarks.benchmark_runner on-device --base_output_directory={BASE_OUTPUT_DIRECTORY} --model_name={model.value} --libtpu_type=maxtext-docker --num_steps=15",
+      ]
+      maxtext_sweep_gke_test = (
+          maxtext_sweep_gke_config.get_maxtext_sweep_gke_config(
+              test_owner=test_owner.RISHABH_B,
+              dataset_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+              composer_project=Project.CLOUD_ML_AUTO_SOLUTIONS.value,
+              dataset_name=metric_config.DatasetOption.XLML_DATASET,
+              cluster=XpkClusters.TPU_V5P_128_CLUSTER,
+              time_out_in_min=360,
+              base_output_directory=BASE_OUTPUT_DIRECTORY,
+              num_slices=[1, 2],
+              docker_image=image.value,
+              run_name_prefix=f"maxtext-{model.name.lower()}-{mode.value}",
+              base_run_model_cmds=base_run_model_cmds,
+              sweep_params=QUANTIZATION_SWEEP,
+          )
+      )
+
+      chain_num = 4
+      prev = maxtext_sweep_gke_test[0].run_with_name_gen_and_quarantine(
+          quarantine_task_group
+      )
+      for i in range(1, len(maxtext_sweep_gke_test)):
+        curr = maxtext_sweep_gke_test[i].run_with_name_gen_and_quarantine(
+            quarantine_task_group
+        )
+        if i % chain_num != 0:
+          prev >> curr
+        prev = curr

--- a/dags/sparsity_diffusion_devx/configs/gke_config.py
+++ b/dags/sparsity_diffusion_devx/configs/gke_config.py
@@ -30,6 +30,7 @@ clusters = {
     "v6e-256": XpkClusters.TPU_V6E_256_MLPERF_CLUSTER,
     "a3": XpkClusters.GPU_A3_CLUSTER,
     "a3plus": XpkClusters.GPU_A3PLUS_CLUSTER,
+    "v5p-128": XpkClusters.TPU_V5P_128_CLUSTER,
 }
 
 

--- a/dags/sparsity_diffusion_devx/maxdiffusion_tpu_e2e.py
+++ b/dags/sparsity_diffusion_devx/maxdiffusion_tpu_e2e.py
@@ -44,11 +44,16 @@ with models.DAG(
     start_date=datetime.datetime(2024, 9, 12),
     catchup=False,
 ) as dag:
-  maxdiffusion_test_configs = {
+  maxdiffusion_test_configs_sdxl = {
       # accelerator: list of slices to test
       "v6e-256": [1, 2],
       "v4-8": [1, 2],
   }
+  maxdiffusion_test_configs_sdv2 = {
+      # accelerator: list of slices to test
+      "v5p-128": [1, 2]
+  }
+
   quarantine_task_group = TaskGroup(
       group_id="Quarantine", dag=dag, prefix_group_id=False
   )
@@ -78,7 +83,17 @@ with models.DAG(
       use_regex_file_location=True,
   )
 
-  for accelerator, slices in maxdiffusion_test_configs.items():
+  sdv2_base_output_dir = (
+      f"{BASE_OUTPUT_DIRECTORY}/maxdiffusion/automated/maxd-sdv2"
+  )
+  sdv2_run_name_prefix = f"maxd-sdv2-jax-stable-stack"
+  sdv2_tensorboard_summary_config = metric_config.SummaryConfig(
+      file_location=sdv2_base_output_dir,
+      aggregation_strategy=metric_config.AggregationStrategy.MEDIAN,
+      use_regex_file_location=True,
+  )
+
+  for accelerator, slices in maxdiffusion_test_configs_sdxl.items():
     cluster = config.clusters[accelerator]
     for slice_num in slices:
       maxdiffusion_sdxl_test = config.get_gke_config(
@@ -126,4 +141,38 @@ with models.DAG(
           run_name_env="JOBSET_NAME",
           nested_run_name_in_tb_file_location=False,
       )
+
       maxdiffusion_sdxl_test >> maxdiffusion_sdxl_nan_test
+
+  for accelerator, slices in maxdiffusion_test_configs_sdv2.items():
+    cluster = config.clusters[accelerator]
+    prev_task = None  # Initialize prev_task to None
+    for slice_num in slices:
+      maxdiffusion_sdv2_test = config.get_gke_config(
+          num_slices=slice_num,
+          cluster=cluster,
+          time_out_in_min=60,
+          run_model_cmds=(
+              f"JAX_PLATFORMS=tpu,cpu ENABLE_PJRT_COMPATIBILITY=true TPU_SLICE_BUILDER_DUMP_CHIP_FORCE=true TPU_SLICE_BUILDER_DUMP_ICI=true JAX_FORCE_TPU_INIT=true ENABLE_TPUNETD_CLIENT=true && "
+              f"pip install . && python src/maxdiffusion/train.py src/maxdiffusion/configs/base_2_base.yml "
+              f"run_name=maxdiffusion-v2-jax-stable-stack "
+              f"jax_cache_dir=gs://jfacevedo-maxdiffusion/cache_dir/ "
+              f"activations_dtype=float32 "
+              f"weights_dtype=float32 "
+              f"per_device_batch_size=2 "
+              f"precision=DEFAULT "
+              f"dataset_save_location=gs://jfacevedo-maxdiffusion-v5p/pokemon-datasets/pokemon-gpt4-captions_xl "
+              f"attention=flash "
+              f"output_dir={sdv2_base_output_dir}",
+          ),
+          test_name=f"maxd-sdv2-{accelerator}-{slice_num}x",
+          docker_image=DockerImage.MAXDIFFUSION_TPU_JAX_STABLE_STACK.value,
+          test_owner=test_owner.PARAM_B,
+      ).run_with_quarantine(quarantine_task_group)
+
+      # Set dependency if there's a previous task
+      if prev_task:
+        prev_task >> maxdiffusion_sdv2_test
+
+      # Update prev_task for the next iteration
+      prev_task = maxdiffusion_sdv2_test


### PR DESCRIPTION
# Description

This test verifies the Orbax Multitier Checkpointing local saving function, with phase 2 replicator enabled. It conducts the following tasks:

Run the MaxText training by enabling the checkpointing, until the local checkpoints have been saved.
Clean up the saved local ram checkpoints.
Using logging explorer API to query log entries during the tests, and verify they contain the logs that local checkpoints have been saved.
Note: The local checkpoints validation is through the logging explorer API, instead of going into the pod and checking the saved checkpoints files.

# Tests

[cluster env](https://pantheon.corp.google.com/kubernetes/clusters/details/europe-west4/b425674043-v5p64/nodes?inv=1&invt=Ab09YQ&project=cloud-tpu-multipod-dev):

project: cloud-tpu-multipod-dev
name: b425674043-v5p64
zone: europe-west4-b
highScaleCheckpointingConfig: enabled
GcsFuseCsiDriver: enabled
Workload Identity Federation: enabled
[gcs bucket](https://pantheon.corp.google.com/storage/browser/mtc-automation-bucket/phase2-20250613-034732/2025-06-13_03-50;tab=objects?e=13802955&inv=1&invt=Ab08_g&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev&prefix=&forceOnObjectsSortingFiltering=false):

name: mtc-automation-bucket
Hierarchical namespace: enabled
[airflow/composer env](https://pantheon.corp.google.com/composer/environments/detail/us-east1/erniechang-test/monitoring?referrer=search&e=13802955&inv=1&invt=Ab1B5w&mods=allow_workbench_image_override&project=cloud-ml-auto-solutions):

project: cloud-ml-auto-solutions
name: erniechang-test
composer version: 2.13.4
airflow version: 2.10.5
test result:
Tests have been conducted in the "cloud-ml-auto-solutions" project with cloud composer.
[Test link](https://3776ea3159a646e4ae176f7424dea099-dot-us-east1.composer.googleusercontent.com/dags/maxtext_multi_tier_sav01_save_local/grid)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.